### PR TITLE
fix: application name in port forward

### DIFF
--- a/kubecon-threat-hunt/README.md
+++ b/kubecon-threat-hunt/README.md
@@ -33,7 +33,7 @@ git clone --depth 1 https://github.com/kubescape/node-agent.git
 cd node-agent
 chmod +x demo/general_attack/webapp/setup.sh
 ./demo/general_attack/webapp/setup.sh
-kubectl port-forward -n default svc/webapp 8080:80
+kubectl port-forward -n default svc/ping-app 8080:80
 ```
 
 This will deploy a sample web application and a service to expose it.


### PR DESCRIPTION
In contribfest I ran through these steps and found the port forward did not work:

```sh
➜  ~ kubectl port-forward -n default svc/webapp 8080:80
Error from server (NotFound): services "webapp" not found
```

So I changed it to the right service:

```sh
➜  ~ kubectl port-forward -n default svc/ping-app 8080:80
Forwarding from 127.0.0.1:8080 -> 80
Forwarding from [::1]:8080 -> 80
Handling connection for 8080
Handling connection for 8080
```